### PR TITLE
Backport CVE-2026-43499 rtmutex fix

### DIFF
--- a/.github/workflows/fastbuild_6.12.23.yml
+++ b/.github/workflows/fastbuild_6.12.23.yml
@@ -80,6 +80,11 @@ on:
         required: true
         type: boolean
         default: 'true'
+      cve_2026_43499_patch:
+        description: '是否应用 CVE-2026-43499 rtmutex 修复补丁'
+        required: true
+        type: boolean
+        default: 'true'
       ccache_update:
         description: '更新ccache缓存(将本次编译生成的ccache缓存覆盖至仓库缓存，在更改编译配置、源码或需要刷新缓存时开启)'
         required: true
@@ -248,6 +253,16 @@ jobs:
           if [ "${{ steps.ccache-restore.outputs.cache-hit }}" == 'true' ]; then
             echo "ccache缓存命中详情:"
             ccache -sv
+          fi
+
+      - name: 应用 CVE_2026_43499 修复补丁
+        id: cve_2026_43499_patch
+        run: |
+          if [[ "${{ github.event.inputs.cve_2026_43499_patch }}" == "true" ]]; then
+            echo ">>> 应用 CVE-2026-43499 rtmutex 修复补丁..."
+            cd kernel_workspace/common
+            wget https://github.com/$GITHUB_REPOSITORY/raw/refs/heads/$GITHUB_REF_NAME/security_patch/cve-2026-43499-rtmutex-6.12.patch
+            patch -p1 -F 3 < cve-2026-43499-rtmutex-6.12.patch
           fi
 
       - name: 添加KernelSU
@@ -769,6 +784,7 @@ jobs:
           echo "ADIOS: ${{ github.event.inputs.adios_enable }}" >> ./ak3.log
           echo "Re-Kernel: ${{ github.event.inputs.rekernel_enable }}" >> ./ak3.log
           echo "BBG: ${{ github.event.inputs.baseband_guard }}" >> ./ak3.log
+          echo "CVE-2026-43499: ${{ github.event.inputs.cve_2026_43499_patch }}" >> ./ak3.log
           zip -z ../$AK3_NAME < ./ak3.log
 
       - name: 上传 Ccache 调试日志
@@ -853,6 +869,7 @@ jobs:
           - ADIOS IO调度器支持：${{ github.event.inputs.adios_enable }}
           - Re-Kernel支持：${{ github.event.inputs.rekernel_enable }}
           - 内核级基带保护支持：${{ github.event.inputs.baseband_guard }}
+          - CVE-2026-43499 rtmutex 修复补丁：${{ github.event.inputs.cve_2026_43499_patch }}
           - ReSukiSU管理器下载：[ReSukiSU_CI](https://github.com/cctv18/ReSukiSU_CI/releases)
           - SukiSU Ultra管理器下载：[SukiSU-Ultra](https://github.com/SukiSU-Ultra/SukiSU-Ultra/releases)
           - KernelSU Next管理器下载：[KernelSU-Next](https://github.com/KernelSU-Next/KernelSU-Next/releases)

--- a/.github/workflows/fastbuild_6.12.23_gki.yml
+++ b/.github/workflows/fastbuild_6.12.23_gki.yml
@@ -80,6 +80,11 @@ on:
         required: true
         type: boolean
         default: 'true'
+      cve_2026_43499_patch:
+        description: '是否应用 CVE-2026-43499 rtmutex 修复补丁'
+        required: true
+        type: boolean
+        default: 'true'
       ccache_update:
         description: '更新ccache缓存(将本次编译生成的ccache缓存覆盖至仓库缓存，在更改编译配置、源码或需要刷新缓存时开启)'
         required: true
@@ -248,6 +253,16 @@ jobs:
           if [ "${{ steps.ccache-restore.outputs.cache-hit }}" == 'true' ]; then
             echo "ccache缓存命中详情:"
             ccache -sv
+          fi
+
+      - name: 应用 CVE_2026_43499 修复补丁
+        id: cve_2026_43499_patch
+        run: |
+          if [[ "${{ github.event.inputs.cve_2026_43499_patch }}" == "true" ]]; then
+            echo ">>> 应用 CVE-2026-43499 rtmutex 修复补丁..."
+            cd kernel_workspace/common
+            wget https://github.com/$GITHUB_REPOSITORY/raw/refs/heads/$GITHUB_REF_NAME/security_patch/cve-2026-43499-rtmutex-6.12.patch
+            patch -p1 -F 3 < cve-2026-43499-rtmutex-6.12.patch
           fi
 
       - name: 添加KernelSU
@@ -769,6 +784,7 @@ jobs:
           echo "ADIOS: ${{ github.event.inputs.adios_enable }}" >> ./ak3.log
           echo "Re-Kernel: ${{ github.event.inputs.rekernel_enable }}" >> ./ak3.log
           echo "BBG: ${{ github.event.inputs.baseband_guard }}" >> ./ak3.log
+          echo "CVE-2026-43499: ${{ github.event.inputs.cve_2026_43499_patch }}" >> ./ak3.log
           zip -z ../$AK3_NAME < ./ak3.log
 
       - name: 上传 Ccache 调试日志
@@ -853,6 +869,7 @@ jobs:
           - ADIOS IO调度器支持：${{ github.event.inputs.adios_enable }}
           - Re-Kernel支持：${{ github.event.inputs.rekernel_enable }}
           - 内核级基带保护支持：${{ github.event.inputs.baseband_guard }}
+          - CVE-2026-43499 rtmutex 修复补丁：${{ github.event.inputs.cve_2026_43499_patch }}
           - ReSukiSU管理器下载：[ReSukiSU_CI](https://github.com/cctv18/ReSukiSU_CI/releases)
           - SukiSU Ultra管理器下载：[SukiSU-Ultra](https://github.com/SukiSU-Ultra/SukiSU-Ultra/releases)
           - KernelSU Next管理器下载：[KernelSU-Next](https://github.com/KernelSU-Next/KernelSU-Next/releases)

--- a/.github/workflows/fastbuild_6.12.23_mtk.yml
+++ b/.github/workflows/fastbuild_6.12.23_mtk.yml
@@ -80,6 +80,11 @@ on:
         required: true
         type: boolean
         default: 'true'
+      cve_2026_43499_patch:
+        description: '是否应用 CVE-2026-43499 rtmutex 修复补丁'
+        required: true
+        type: boolean
+        default: 'true'
       ccache_update:
         description: '更新ccache缓存(将本次编译生成的ccache缓存覆盖至仓库缓存，在更改编译配置、源码或需要刷新缓存时开启)'
         required: true
@@ -248,6 +253,16 @@ jobs:
           if [ "${{ steps.ccache-restore.outputs.cache-hit }}" == 'true' ]; then
             echo "ccache缓存命中详情:"
             ccache -sv
+          fi
+
+      - name: 应用 CVE_2026_43499 修复补丁
+        id: cve_2026_43499_patch
+        run: |
+          if [[ "${{ github.event.inputs.cve_2026_43499_patch }}" == "true" ]]; then
+            echo ">>> 应用 CVE-2026-43499 rtmutex 修复补丁..."
+            cd kernel_workspace/common
+            wget https://github.com/$GITHUB_REPOSITORY/raw/refs/heads/$GITHUB_REF_NAME/security_patch/cve-2026-43499-rtmutex-6.12.patch
+            patch -p1 -F 3 < cve-2026-43499-rtmutex-6.12.patch
           fi
 
       - name: 添加KernelSU
@@ -769,6 +784,7 @@ jobs:
           echo "ADIOS: ${{ github.event.inputs.adios_enable }}" >> ./ak3.log
           echo "Re-Kernel: ${{ github.event.inputs.rekernel_enable }}" >> ./ak3.log
           echo "BBG: ${{ github.event.inputs.baseband_guard }}" >> ./ak3.log
+          echo "CVE-2026-43499: ${{ github.event.inputs.cve_2026_43499_patch }}" >> ./ak3.log
           zip -z ../$AK3_NAME < ./ak3.log
 
       - name: 上传 Ccache 调试日志
@@ -853,6 +869,7 @@ jobs:
           - ADIOS IO调度器支持：${{ github.event.inputs.adios_enable }}
           - Re-Kernel支持：${{ github.event.inputs.rekernel_enable }}
           - 内核级基带保护支持：${{ github.event.inputs.baseband_guard }}
+          - CVE-2026-43499 rtmutex 修复补丁：${{ github.event.inputs.cve_2026_43499_patch }}
           - ReSukiSU管理器下载：[ReSukiSU_CI](https://github.com/cctv18/ReSukiSU_CI/releases)
           - SukiSU Ultra管理器下载：[SukiSU-Ultra](https://github.com/SukiSU-Ultra/SukiSU-Ultra/releases)
           - KernelSU Next管理器下载：[KernelSU-Next](https://github.com/KernelSU-Next/KernelSU-Next/releases)

--- a/.github/workflows/fastbuild_6.12.38.yml
+++ b/.github/workflows/fastbuild_6.12.38.yml
@@ -80,6 +80,11 @@ on:
         required: true
         type: boolean
         default: 'true'
+      cve_2026_43499_patch:
+        description: '是否应用 CVE-2026-43499 rtmutex 修复补丁'
+        required: true
+        type: boolean
+        default: 'true'
       ccache_update:
         description: '更新ccache缓存(将本次编译生成的ccache缓存覆盖至仓库缓存，在更改编译配置、源码或需要刷新缓存时开启)'
         required: true
@@ -248,6 +253,16 @@ jobs:
           if [ "${{ steps.ccache-restore.outputs.cache-hit }}" == 'true' ]; then
             echo "ccache缓存命中详情:"
             ccache -sv
+          fi
+      
+      - name: 应用 CVE_2026_43499 修复补丁
+        id: cve_2026_43499_patch
+        run: |
+          if [[ "${{ github.event.inputs.cve_2026_43499_patch }}" == "true" ]]; then
+            echo ">>> 应用 CVE-2026-43499 rtmutex 修复补丁..."
+            cd kernel_workspace/common
+            wget https://github.com/$GITHUB_REPOSITORY/raw/refs/heads/$GITHUB_REF_NAME/security_patch/cve-2026-43499-rtmutex-6.12.patch
+            patch -p1 -F 3 < cve-2026-43499-rtmutex-6.12.patch
           fi
 
       - name: 添加KernelSU
@@ -769,6 +784,7 @@ jobs:
           echo "ADIOS: ${{ github.event.inputs.adios_enable }}" >> ./ak3.log
           echo "Re-Kernel: ${{ github.event.inputs.rekernel_enable }}" >> ./ak3.log
           echo "BBG: ${{ github.event.inputs.baseband_guard }}" >> ./ak3.log
+          echo "CVE-2026-43499: ${{ github.event.inputs.cve_2026_43499_patch }}" >> ./ak3.log
           zip -z ../$AK3_NAME < ./ak3.log
 
       - name: 上传 Ccache 调试日志
@@ -853,6 +869,7 @@ jobs:
           - ADIOS IO调度器支持：${{ github.event.inputs.adios_enable }}
           - Re-Kernel支持：${{ github.event.inputs.rekernel_enable }}
           - 内核级基带保护支持：${{ github.event.inputs.baseband_guard }}
+          - CVE-2026-43499 rtmutex 修复补丁：${{ github.event.inputs.cve_2026_43499_patch }}
           - ReSukiSU管理器下载：[ReSukiSU_CI](https://github.com/cctv18/ReSukiSU_CI/releases)
           - SukiSU Ultra管理器下载：[SukiSU-Ultra](https://github.com/SukiSU-Ultra/SukiSU-Ultra/releases)
           - KernelSU Next管理器下载：[KernelSU-Next](https://github.com/KernelSU-Next/KernelSU-Next/releases)

--- a/local/builder_6.12.23.sh
+++ b/local/builder_6.12.23.sh
@@ -33,6 +33,8 @@ read -p "是否启用Re-Kernel？(y/n，默认：n): " APPLY_REKERNEL
 APPLY_REKERNEL=${APPLY_REKERNEL:-n}
 read -p "是否启用内核级基带保护？(y/n，默认：y): " APPLY_BBG
 APPLY_BBG=${APPLY_BBG:-y}
+read -p "是否应用 CVE-2026-43499 rtmutex 修复补丁？(y/n，默认：y): " APPLY_CVE_2026_43499
+APPLY_CVE_2026_43499=${APPLY_CVE_2026_43499:-y}
 
 if [[ "$KSU_BRANCH" == "y" || "$KSU_BRANCH" == "Y" ]]; then
   KSU_TYPE="SukiSU Ultra"
@@ -61,6 +63,7 @@ echo "应用 Droidspaces 容器支持: $APPLY_DROIDSPACES"
 echo "启用ADIOS调度器: $APPLY_ADIOS"
 echo "启用Re-Kernel: $APPLY_REKERNEL"
 echo "启用内核级基带保护: $APPLY_BBG"
+echo "应用 CVE-2026-43499 修复补丁: $APPLY_CVE_2026_43499"
 echo "===================="
 echo
 
@@ -130,6 +133,14 @@ done
 sudo sed -i 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION="-'${CUSTOM_SUFFIX}'"/' ./common/arch/arm64/configs/gki_defconfig
 sed -i 's/${scm_version}//' ./common/scripts/setlocalversion
 echo "CONFIG_LOCALVERSION_AUTO=n" >> ./common/arch/arm64/configs/gki_defconfig
+
+# ===== 应用 CVE-2026-43499 修复补丁 =====
+if [[ "$APPLY_CVE_2026_43499" == [yY] ]]; then
+  echo ">>> 应用 CVE-2026-43499 rtmutex 修复补丁..."
+  cd common
+  patch -p1 -F 3 < "$WORKDIR/../security_patch/cve-2026-43499-rtmutex-6.12.patch"
+  cd ..
+fi
 
 # ===== 拉取 KSU 并设置版本号 =====
 if [[ $KSU_BRANCH == [yYrR] ]]; then

--- a/local/builder_6.12.23_gki.sh
+++ b/local/builder_6.12.23_gki.sh
@@ -33,6 +33,8 @@ read -p "是否启用Re-Kernel？(y/n，默认：n): " APPLY_REKERNEL
 APPLY_REKERNEL=${APPLY_REKERNEL:-n}
 read -p "是否启用内核级基带保护？(y/n，默认：y): " APPLY_BBG
 APPLY_BBG=${APPLY_BBG:-y}
+read -p "是否应用 CVE-2026-43499 rtmutex 修复补丁？(y/n，默认：y): " APPLY_CVE_2026_43499
+APPLY_CVE_2026_43499=${APPLY_CVE_2026_43499:-y}
 
 if [[ "$KSU_BRANCH" == "y" || "$KSU_BRANCH" == "Y" ]]; then
   KSU_TYPE="SukiSU Ultra"
@@ -61,6 +63,7 @@ echo "应用 Droidspaces 容器支持: $APPLY_DROIDSPACES"
 echo "启用ADIOS调度器: $APPLY_ADIOS"
 echo "启用Re-Kernel: $APPLY_REKERNEL"
 echo "启用内核级基带保护: $APPLY_BBG"
+echo "应用 CVE-2026-43499 修复补丁: $APPLY_CVE_2026_43499"
 echo "===================="
 echo
 
@@ -130,6 +133,14 @@ done
 sudo sed -i 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION="-'${CUSTOM_SUFFIX}'"/' ./common/arch/arm64/configs/gki_defconfig
 sed -i 's/${scm_version}//' ./common/scripts/setlocalversion
 echo "CONFIG_LOCALVERSION_AUTO=n" >> ./common/arch/arm64/configs/gki_defconfig
+
+# ===== 应用 CVE-2026-43499 修复补丁 =====
+if [[ "$APPLY_CVE_2026_43499" == [yY] ]]; then
+  echo ">>> 应用 CVE-2026-43499 rtmutex 修复补丁..."
+  cd common
+  patch -p1 -F 3 < "$WORKDIR/../security_patch/cve-2026-43499-rtmutex-6.12.patch"
+  cd ..
+fi
 
 # ===== 拉取 KSU 并设置版本号 =====
 if [[ $KSU_BRANCH == [yYrR] ]]; then

--- a/local/builder_6.12.23_mtk.sh
+++ b/local/builder_6.12.23_mtk.sh
@@ -33,6 +33,8 @@ read -p "是否启用Re-Kernel？(y/n，默认：n): " APPLY_REKERNEL
 APPLY_REKERNEL=${APPLY_REKERNEL:-n}
 read -p "是否启用内核级基带保护？(y/n，默认：y): " APPLY_BBG
 APPLY_BBG=${APPLY_BBG:-y}
+read -p "是否应用 CVE-2026-43499 rtmutex 修复补丁？(y/n，默认：y): " APPLY_CVE_2026_43499
+APPLY_CVE_2026_43499=${APPLY_CVE_2026_43499:-y}
 
 if [[ "$KSU_BRANCH" == "y" || "$KSU_BRANCH" == "Y" ]]; then
   KSU_TYPE="SukiSU Ultra"
@@ -61,6 +63,7 @@ echo "应用 Droidspaces 容器支持: $APPLY_DROIDSPACES"
 echo "启用ADIOS调度器: $APPLY_ADIOS"
 echo "启用Re-Kernel: $APPLY_REKERNEL"
 echo "启用内核级基带保护: $APPLY_BBG"
+echo "应用 CVE-2026-43499 修复补丁: $APPLY_CVE_2026_43499"
 echo "===================="
 echo
 
@@ -130,6 +133,14 @@ done
 sudo sed -i 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION="-'${CUSTOM_SUFFIX}'"/' ./common/arch/arm64/configs/gki_defconfig
 sed -i 's/${scm_version}//' ./common/scripts/setlocalversion
 echo "CONFIG_LOCALVERSION_AUTO=n" >> ./common/arch/arm64/configs/gki_defconfig
+
+# ===== 应用 CVE-2026-43499 修复补丁 =====
+if [[ "$APPLY_CVE_2026_43499" == [yY] ]]; then
+  echo ">>> 应用 CVE-2026-43499 rtmutex 修复补丁..."
+  cd common
+  patch -p1 -F 3 < "$WORKDIR/../security_patch/cve-2026-43499-rtmutex-6.12.patch"
+  cd ..
+fi
 
 # ===== 拉取 KSU 并设置版本号 =====
 if [[ $KSU_BRANCH == [yYrR] ]]; then

--- a/local/builder_6.12.38.sh
+++ b/local/builder_6.12.38.sh
@@ -33,6 +33,8 @@ read -p "是否启用Re-Kernel？(y/n，默认：n): " APPLY_REKERNEL
 APPLY_REKERNEL=${APPLY_REKERNEL:-n}
 read -p "是否启用内核级基带保护？(y/n，默认：y): " APPLY_BBG
 APPLY_BBG=${APPLY_BBG:-y}
+read -p "是否应用 CVE-2026-43499 rtmutex 修复补丁？(y/n，默认：y): " APPLY_CVE_2026_43499
+APPLY_CVE_2026_43499=${APPLY_CVE_2026_43499:-y}
 
 if [[ "$KSU_BRANCH" == "y" || "$KSU_BRANCH" == "Y" ]]; then
   KSU_TYPE="SukiSU Ultra"
@@ -61,6 +63,7 @@ echo "应用 Droidspaces 容器支持: $APPLY_DROIDSPACES"
 echo "启用ADIOS调度器: $APPLY_ADIOS"
 echo "启用Re-Kernel: $APPLY_REKERNEL"
 echo "启用内核级基带保护: $APPLY_BBG"
+echo "应用 CVE-2026-43499 修复补丁: $APPLY_CVE_2026_43499"
 echo "===================="
 echo
 
@@ -130,6 +133,14 @@ done
 sudo sed -i 's/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION="-'${CUSTOM_SUFFIX}'"/' ./common/arch/arm64/configs/gki_defconfig
 sed -i 's/${scm_version}//' ./common/scripts/setlocalversion
 echo "CONFIG_LOCALVERSION_AUTO=n" >> ./common/arch/arm64/configs/gki_defconfig
+
+# ==== 应用 CVE-2026-43499 修复补丁 =====
+if [[ "$APPLY_CVE_2026_43499" == [yY] ]]; then
+  echo ">>> 应用 CVE-2026-43499 rtmutex 修复补丁..."
+  cd common
+  patch -p1 -F 3 < "$WORKDIR/../security_patch/cve-2026-43499-rtmutex-6.12.patch"
+  cd ..
+fi
 
 # ===== 拉取 KSU 并设置版本号 =====
 if [[ $KSU_BRANCH == [yYrR] ]]; then

--- a/security_patch/cve-2026-43499-rtmutex-6.12.patch
+++ b/security_patch/cve-2026-43499-rtmutex-6.12.patch
@@ -1,0 +1,40 @@
+diff -uprN -x .DS_Store a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
+--- a/kernel/locking/rtmutex.c	2026-03-17 04:30:12
++++ b/kernel/locking/rtmutex.c	2026-07-08 19:00:27
+@@ -1536,20 +1536,23 @@ static bool rtmutex_spin_on_owner(struct rt_mutex_base
+  *
+  * Must be called with lock->wait_lock held and interrupts disabled. It must
+  * have just failed to try_to_take_rt_mutex().
++ *
++ * When invoked from rt_mutex_start_proxy_lock() waiter::task != current !
+  */
+ static void __sched remove_waiter(struct rt_mutex_base *lock,
+ 				  struct rt_mutex_waiter *waiter)
+ {
+ 	bool is_top_waiter = (waiter == rt_mutex_top_waiter(lock));
+ 	struct task_struct *owner = rt_mutex_owner(lock);
++	struct task_struct *waiter_task = waiter->task;
+ 	struct rt_mutex_base *next_lock;
+ 
+ 	lockdep_assert_held(&lock->wait_lock);
+ 
+-	raw_spin_lock(&current->pi_lock);
+-	rt_mutex_dequeue(lock, waiter);
+-	current->pi_blocked_on = NULL;
+-	raw_spin_unlock(&current->pi_lock);
++	scoped_guard(raw_spinlock, &waiter_task->pi_lock) {
++		rt_mutex_dequeue(lock, waiter);
++		waiter_task->pi_blocked_on = NULL;
++	}
+ 
+ 	/*
+ 	 * Only update priority if the waiter was the highest priority
+@@ -1585,7 +1588,7 @@ static void __sched remove_waiter(struct rt_mutex_base
+ 	raw_spin_unlock_irq(&lock->wait_lock);
+ 
+ 	rt_mutex_adjust_prio_chain(owner, RT_MUTEX_MIN_CHAINWALK, lock,
+-				   next_lock, NULL, current);
++				   next_lock, NULL, waiter_task);
+ 
+ 	raw_spin_lock_irq(&lock->wait_lock);
+ }

--- a/security_patch/cve-2026-43499-rtmutex-6.12.patch
+++ b/security_patch/cve-2026-43499-rtmutex-6.12.patch
@@ -1,7 +1,7 @@
 diff -uprN -x .DS_Store a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
 --- a/kernel/locking/rtmutex.c	2026-03-17 04:30:12
 +++ b/kernel/locking/rtmutex.c	2026-07-08 19:00:27
-@@ -1536,20 +1536,23 @@ static bool rtmutex_spin_on_owner(struct rt_mutex_base
+@@ -1536,20 +1536,26 @@ static bool rtmutex_spin_on_owner(struct rt_mutex_base
   *
   * Must be called with lock->wait_lock held and interrupts disabled. It must
   * have just failed to try_to_take_rt_mutex().
@@ -18,6 +18,9 @@ diff -uprN -x .DS_Store a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
  
  	lockdep_assert_held(&lock->wait_lock);
  
++	if (!waiter_task) /* never enqueued */
++		return;
++
 -	raw_spin_lock(&current->pi_lock);
 -	rt_mutex_dequeue(lock, waiter);
 -	current->pi_blocked_on = NULL;
@@ -29,7 +32,7 @@ diff -uprN -x .DS_Store a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
  
  	/*
  	 * Only update priority if the waiter was the highest priority
-@@ -1585,7 +1588,7 @@ static void __sched remove_waiter(struct rt_mutex_base
+@@ -1585,7 +1591,7 @@ static void __sched remove_waiter(struct rt_mutex_base
  	raw_spin_unlock_irq(&lock->wait_lock);
  
  	rt_mutex_adjust_prio_chain(owner, RT_MUTEX_MIN_CHAINWALK, lock,
@@ -38,3 +41,15 @@ diff -uprN -x .DS_Store a/kernel/locking/rtmutex.c b/kernel/locking/rtmutex.c
  
  	raw_spin_lock_irq(&lock->wait_lock);
  }
+diff --git a/kernel/locking/rtmutex_api.c b/kernel/locking/rtmutex_api.c
+--- a/kernel/locking/rtmutex_api.c
++++ b/kernel/locking/rtmutex_api.c
+@@ -352,7 +352,7 @@ int __sched rt_mutex_start_proxy_lock(struct rt_mutex_base *lock,
+ 
+ 	raw_spin_lock_irq(&lock->wait_lock);
+ 	ret = __rt_mutex_start_proxy_lock(lock, waiter, task, &wake_q);
+-	if (unlikely(ret))
++	if (unlikely(ret < 0))
+ 		remove_waiter(lock, waiter);
+ 	preempt_disable();
+ 	raw_spin_unlock_irq(&lock->wait_lock);


### PR DESCRIPTION
把 6.12.86 的修复移植下来了，小米 17pm 实测 poc 已失效
<img width="589" height="1280" alt="IMAGE 2026-07-08 21:40:33" src="https://github.com/user-attachments/assets/71c15484-9d1b-4d93-8fa4-2ae7bda93f01" />
<img width="1178" height="2560" alt="IMAGE 2026-07-08 21:40:38" src="https://github.com/user-attachments/assets/444ee325-73ac-43b2-8ebe-cc6a69b1a806" />
